### PR TITLE
Add flags to disable riding & leashing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>net.milkbowl.vault</groupId>
+			<groupId>com.github.MilkBowl</groupId>
 			<artifactId>VaultAPI</artifactId>
 			<version>1.7</version>
 			<scope>provided</scope>

--- a/src/main/java/com/hm/petmaster/PetMaster.java
+++ b/src/main/java/com/hm/petmaster/PetMaster.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 
 import com.hm.petmaster.listener.PlayerAttackListener;
+import com.hm.petmaster.listener.PlayerLeashListener;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -53,6 +54,7 @@ public class PetMaster extends JavaPlugin {
 
 	// Plugin listeners.
 	private PlayerInteractListener playerInteractListener;
+	private PlayerLeashListener playerLeashListener;
 	private PlayerQuitListener playerQuitListener;
 	private PlayerAttackListener playerAttackListener;
 
@@ -78,11 +80,13 @@ public class PetMaster extends JavaPlugin {
 		getLogger().info("Registering listeners...");
 
 		playerInteractListener = new PlayerInteractListener(this);
+		playerLeashListener = new PlayerLeashListener(this);
 		playerQuitListener = new PlayerQuitListener(this);
 
 		PluginManager pm = getServer().getPluginManager();
 		// Register listeners.
 		pm.registerEvents(playerInteractListener, this);
+		pm.registerEvents(playerLeashListener, this);
 		pm.registerEvents(playerQuitListener, this);
 
 		extractParametersFromConfig(true);

--- a/src/main/java/com/hm/petmaster/listener/PlayerInteractListener.java
+++ b/src/main/java/com/hm/petmaster/listener/PlayerInteractListener.java
@@ -6,16 +6,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
-import org.bukkit.entity.AnimalTamer;
-import org.bukkit.entity.Animals;
-import org.bukkit.entity.Cat;
-import org.bukkit.entity.Llama;
-import org.bukkit.entity.Ocelot;
-import org.bukkit.entity.Parrot;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Sittable;
-import org.bukkit.entity.Tameable;
-import org.bukkit.entity.Wolf;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -66,6 +57,7 @@ public class PlayerInteractListener implements Listener {
 	private int changeOwnerPrice;
 	private int freePetPrice;
 	private boolean showHealth;
+	private boolean disableRiding;
 
 	public PlayerInteractListener(PetMaster petMaster) {
 		this.plugin = petMaster;
@@ -94,6 +86,7 @@ public class PlayerInteractListener implements Listener {
 		hologramMessage = plugin.getPluginConfig().getBoolean("hologramMessage", false);
 		actionBarMessage = plugin.getPluginConfig().getBoolean("actionBarMessage", true);
 		showHealth = plugin.getPluginConfig().getBoolean("showHealth", true);
+		disableRiding = plugin.getPluginConfig().getBoolean("disableRiding", false);
 
 		boolean holographicDisplaysAvailable = Bukkit.getPluginManager().isPluginEnabled("HolographicDisplays");
 		// Checking whether user configured plugin to display hologram but HolographicsDisplays not available.
@@ -105,7 +98,7 @@ public class PlayerInteractListener implements Listener {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPlayerInteractEntityEvent(PlayerInteractEntityEvent event) {
 		if (shouldHandleEvent(event)) {
 			Tameable tameable = (Tameable) event.getRightClicked();
@@ -126,6 +119,12 @@ public class PlayerInteractListener implements Listener {
 				player.sendMessage(plugin.getChatHeader() + plugin.getPluginLang()
 						.getString("not-owner", "You do not own this pet!").replace("PLAYER", player.getName()));
 				return;
+			}
+
+			if (disableRiding && !isOwner && tameable instanceof AbstractHorse) {
+				player.sendMessage(plugin.getChatHeader() + plugin.getPluginLang()
+						.getString("not-owner", "You do not own this pet!").replace("PLAYER", player.getName()));
+				event.setCancelled(true);
 			}
 
 			if (newOwner != null) {

--- a/src/main/java/com/hm/petmaster/listener/PlayerLeashListener.java
+++ b/src/main/java/com/hm/petmaster/listener/PlayerLeashListener.java
@@ -1,0 +1,48 @@
+package com.hm.petmaster.listener;
+
+import com.hm.mcshared.particle.ReflectionUtils;
+import com.hm.petmaster.PetMaster;
+import org.bukkit.entity.AnimalTamer;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Tameable;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerLeashEntityEvent;
+
+public class PlayerLeashListener implements Listener {
+    private final PetMaster plugin;
+    private final int version;
+
+    // Configuration parameters.
+    private boolean disableLeash;
+
+    public PlayerLeashListener(PetMaster petMaster) {
+        this.plugin = petMaster;
+        version = Integer.parseInt(ReflectionUtils.PackageType.getServerVersion().split("_")[1]);
+	}
+
+    public void extractParameters() {
+        disableLeash = plugin.getPluginConfig().getBoolean("disableLeash", false);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerLeashEntityEvent(PlayerLeashEntityEvent event) {
+        if (plugin.getEnableDisableCommand().isDisabled() || !disableLeash)
+            return;
+        Entity entity = event.getEntity();
+        if (!(entity instanceof Tameable))
+            return;
+
+        Player player = event.getPlayer();
+        Tameable tameable = (Tameable) entity;
+        AnimalTamer currentOwner = tameable.getOwner();
+        if (currentOwner == null || currentOwner.getUniqueId().equals(player.getUniqueId()))
+            return;
+
+        player.sendMessage(plugin.getChatHeader() + plugin.getPluginLang()
+                .getString("not-owner", "You do not own this pet!").replace("PLAYER", player.getName()));
+        event.setCancelled(true);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -60,6 +60,12 @@ displayLlama: true
 # Take parrots into account.
 displayParrot: true
 
+# Prevent others from using lead on pet.
+disableLeash: false
+
+# Prevent others from mounting pet (horse/donkey).
+disableRiding: false
+
 # Protect pets to avoid being hurt by other player.
 disablePlayerDamage: false
 


### PR DESCRIPTION
This adds 2 flags:
1. `disableLeash` - This prevents players from using a lead on pets owned by others.
2. `disableRiding` - This prevents players from riding horses & donkeys owned by others.

Also including a fix for the vault maven group ID, as the old one no longer exists.