### PR TITLE
Add flags to disable riding & leashing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>net.milkbowl.vault</groupId>
+			<groupId>com.github.MilkBowl</groupId>
 			<artifactId>VaultAPI</artifactId>
 			<version>1.7</version>
 			<scope>provided</scope>

--- a/src/main/java/com/hm/petmaster/PetMaster.java
+++ b/src/main/java/com/hm/petmaster/PetMaster.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 
 import com.hm.petmaster.listener.PlayerAttackListener;
+import com.hm.petmaster.listener.PlayerLeashListener;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -53,6 +54,7 @@ public class PetMaster extends JavaPlugin {
 
 	// Plugin listeners.
 	private PlayerInteractListener playerInteractListener;
+	private PlayerLeashListener playerLeashListener;
 	private PlayerQuitListener playerQuitListener;
 	private PlayerAttackListener playerAttackListener;
 
@@ -78,11 +80,13 @@ public class PetMaster extends JavaPlugin {
 		getLogger().info("Registering listeners...");
 
 		playerInteractListener = new PlayerInteractListener(this);
+		playerLeashListener = new PlayerLeashListener(this);
 		playerQuitListener = new PlayerQuitListener(this);
 
 		PluginManager pm = getServer().getPluginManager();
 		// Register listeners.
 		pm.registerEvents(playerInteractListener, this);
+		pm.registerEvents(playerLeashListener, this);
 		pm.registerEvents(playerQuitListener, this);
 
 		extractParametersFromConfig(true);
@@ -123,6 +127,7 @@ public class PetMaster extends JavaPlugin {
 		}
 
 		playerInteractListener.extractParameters();
+		playerLeashListener.extractParameters();
 
 		if (config.getBoolean("checkForUpdate", true)) {
 			if (updateChecker == null) {

--- a/src/main/java/com/hm/petmaster/listener/PlayerLeashListener.java
+++ b/src/main/java/com/hm/petmaster/listener/PlayerLeashListener.java
@@ -1,0 +1,48 @@
+package com.hm.petmaster.listener;
+
+import com.hm.mcshared.particle.ReflectionUtils;
+import com.hm.petmaster.PetMaster;
+import org.bukkit.entity.AnimalTamer;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Tameable;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerLeashEntityEvent;
+
+public class PlayerLeashListener implements Listener {
+    private final PetMaster plugin;
+    private final int version;
+
+    // Configuration parameters.
+    private boolean disableLeash;
+
+    public PlayerLeashListener(PetMaster petMaster) {
+        this.plugin = petMaster;
+        version = Integer.parseInt(ReflectionUtils.PackageType.getServerVersion().split("_")[1]);
+	}
+
+    public void extractParameters() {
+        disableLeash = plugin.getPluginConfig().getBoolean("disableLeash", false);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerLeashEntityEvent(PlayerLeashEntityEvent event) {
+        if (plugin.getEnableDisableCommand().isDisabled() || !disableLeash)
+            return;
+        Entity entity = event.getEntity();
+        if (!(entity instanceof Tameable))
+            return;
+
+        Player player = event.getPlayer();
+        Tameable tameable = (Tameable) entity;
+        AnimalTamer currentOwner = tameable.getOwner();
+        if (currentOwner == null || currentOwner.getUniqueId().equals(player.getUniqueId()) || player.hasPermission("petmaster.admin"))
+            return;
+
+        player.sendMessage(plugin.getChatHeader() + plugin.getPluginLang()
+                .getString("not-owner", "You do not own this pet!").replace("PLAYER", player.getName()));
+        event.setCancelled(true);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -60,6 +60,12 @@ displayLlama: true
 # Take parrots into account.
 displayParrot: true
 
+# Prevent others from using lead on pet.
+disableLeash: false
+
+# Prevent others from mounting pet (horse/donkey).
+disableRiding: false
+
 # Protect pets to avoid being hurt by other player.
 disablePlayerDamage: false
 


### PR DESCRIPTION
Resubmit of #35 since github decided to close it and won't let me re-open.

This adds 2 flags:

disableLeash - This prevents players from using a lead on pets owned by others.
disableRiding - This prevents players from riding horses & donkeys owned by others.
Also including a fix for the vault maven group ID, as the old one no longer exists.