### PR TITLE
fix: added escape character to help messages, so they would display

### DIFF
--- a/src/main/java/com/hm/petmaster/utils/MessageSender.java
+++ b/src/main/java/com/hm/petmaster/utils/MessageSender.java
@@ -85,4 +85,14 @@ public class MessageSender {
         Audience audience = plugin.adventure().player(player);
         sendActionBar(audience, key, templates);
     }
+
+    public void sendNewLine(CommandSender sender, boolean sendPrefix){
+        Audience audience = plugin.adventure().sender(sender);
+
+        if (sendPrefix){
+            sendMessage(audience, "petmaster-prefix", new ArrayList<>());
+        } else {
+            audience.sendMessage(Component.newline());
+        }
+    }
 }

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -37,10 +37,10 @@ available-colors: "<prefix> The following colors are available: <colors>"
 color-successfully-set: "<prefix> Color successfully changed."
 
 # Related to /petm help.
-petmaster-help-header: "<prefix> <gold>------------------ ♞<bold>PetMaster</bold>♞  ------------------"
-petmaster-command-setowner: "<prefix> <hover:show_text:'You can only change the ownershipof your own pets, unless you're admin!'><click:suggest_command:/petm setowner><gold>/petm setowner [player]<gray></click></hover>Change the ownership of a pet."
+petmaster-help-header: "<prefix> <gold>------------------ ♞ <bold>PetMaster</bold> ♞  ------------------"
+petmaster-command-setowner: "<prefix> <hover:show_text:'You can only change the ownershipof your own pets, unless you\\'re admin!'><click:suggest_command:/petm setowner><gold>/petm setowner [player]<gray></click></hover> Change the ownership of a pet."
 petmaster-command-setcolor: "<prefix> <hover:show_text:'Currently tamed pets are unaffected.'><click:suggest_command:/petm setcolor><gold>/petm setcolor [color]<gray></click></hover> Set the color of the collars of all pets tamed in the future."
-petmaster-command-free: "<prefix> <hover:show_text:'You can only free your own pets,unless you're admin!'><click:suggest_command:/petm free><gold>/petm free<gray></click></hover> Free a pet."
+petmaster-command-free: "<prefix> <hover:show_text:'You can only free your own pets, unless you\\'re admin!'><click:suggest_command:/petm free><gold>/petm free<gray></click></hover> Free a pet."
 petmaster-command-disable: "<prefix> <hover:show_text:'The plugin will not work untilnext reload or /petm enable.'><click:suggest_command:/petm disable><gold>/petm disable<gray></click></hover> Disable the plugin."
 petmaster-command-enable: "<prefix> <hover:show_text:'Plugin enabled by default. Usethis if you entered /petm disable before!'><click:suggest_command:/petm enable><gold>/petm enable<gray></click></hover> Enable the plugin."
 petmaster-command-reload: "<prefix> <hover:show_text:'Reload most settings in config.ymland lang.yml files.'><click:suggest_command:/petm reload><gold>/petm reload<gray></click></hover> Reload the plugin's configuration."


### PR DESCRIPTION
Missed two escape characters in the hover messages, which broke some help messages.
Also added a method for future use.